### PR TITLE
Start SARS-Arena in windows OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,14 @@ SARS-Arena: Sequence and Structure-Guided Selection of Conserved Peptides from S
 
 &nbsp;
 
-3. Clone this repo and run the following command in the terminal:
+3. Clone this repo and run the following command in the terminal[^1]:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;On Linux or Mac: `./start_SARS-Arena.sh`
   
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;On Windows: `./start_SARS-Arena.ps1` (using PowerShell)
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_In PowerShell, make sure you have permissions to execute the script, if you get an error_ `***  cannot be loaded because the execution of scripts is disabled on this system.` _follow these [tips](https://stackoverflow.com/questions/4037939/powershell-says-execution-of-scripts-is-disabled-on-this-system)._
-  
-  &nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;On Windows: `./start_SARS-Arena.ps1` (using PowerShell [^2]) 
+ 
+ 
+&nbsp;
 
 4. This should generate a URL with the following format:
 
@@ -42,4 +41,8 @@ SARS-Arena: Sequence and Structure-Guided Selection of Conserved Peptides from S
 
 Enjoy SARS-Arena!
 
- 
+&nbsp;
+&nbsp;
+ [^1]: If you experience issues starting the container in the step 3 with the start script you can run the raw commands directly `docker run --rm -v $(pwd):/data -p 8888:8888 --entrypoint=""  kavrakilab/hla-arena:sars-arena jupyter notebook --port=8888 --no-browser --ip=0.0.0.0 --allow-root` (for Linux/MacOS) or `docker run --rm -v ${pwd}:/data -p 8888:8888 --entrypoint=""  kavrakilab/hla-arena:sars-arena jupyter notebook --port=8888 --no-browser --ip=0.0.0.0 --allow-root`(for Windows).
+
+[^2]: In PowerShell, make sure you have permissions to execute the script, if you get an error_ `***  cannot be loaded because the execution of scripts is disabled on this system.` _follow these [tips](https://stackoverflow.com/questions/4037939/powershell-says-execution-of-scripts-is-disabled-on-this-system) to enable running scripts.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ SARS-Arena: Sequence and Structure-Guided Selection of Conserved Peptides from S
 
 3. Clone this repo and run the following command in the terminal:
 
-  `./start_SARS-Arena.sh`
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;On Linux or Mac: `./start_SARS-Arena.sh`
+  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;On Windows: `./start_SARS-Arena.ps1` (using PowerShell)
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;_In PowerShell, make sure you have permissions to execute the script, if you get an error_ `***  cannot be loaded because the execution of scripts is disabled on this system.` _follow these [tips](https://stackoverflow.com/questions/4037939/powershell-says-execution-of-scripts-is-disabled-on-this-system)._
   
   &nbsp;
 

--- a/start_SARS-Arena.ps1
+++ b/start_SARS-Arena.ps1
@@ -1,0 +1,1 @@
+docker run --rm -v ${pwd}:/data -p 8888:8888 --entrypoint=""  kavrakilab/hla-arena:sars-arena jupyter notebook --port=8888 --no-browser --ip=0.0.0.0 --allow-root


### PR DESCRIPTION
Start SARS-Arena from Windows using a Powershell script!

Added: start_SARS-Arena.ps1 as a script that can be run by PowerShell in Windows

Main change: `$(pwd)` to `${pwd}` to adhere to windows syntax. 